### PR TITLE
It dies on malformed %YAML directive

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -245,20 +245,20 @@ var directiveHandlers = {
 
       if (null === match) {
         throwError(state, 'ill-formed argument of the YAML directive');
-      }
-
-      major = parseInt(match[1], 10);
-      minor = parseInt(match[2], 10);
-
-      if (1 !== major) {
-        throwError(state, 'found incompatible YAML document (version 1.2 is required)');
-      }
-
-      state.version = args[0];
-      state.checkLineBreaks = (minor < 2);
-
-      if (2 !== minor) {
-        throwError(state, 'found incompatible YAML document (version 1.2 is required)');
+      } else {
+        major = parseInt(match[1], 10);
+        minor = parseInt(match[2], 10);
+  
+        if (1 !== major) {
+          throwError(state, 'found incompatible YAML document (version 1.2 is required)');
+        }
+  
+        state.version = args[0];
+        state.checkLineBreaks = (minor < 2);
+  
+        if (2 !== minor) {
+          throwError(state, 'found incompatible YAML document (version 1.2 is required)');
+        }
       }
     },
 


### PR DESCRIPTION
What is the FIXME on line 186?
Why is line 216 commented?

Example of breaking code:

``` javascript
const y = require('yaml-ast-parser');

function printResult(){ console.log(arguments) }

y.loadAll(
`%YAML 12

---
a: 123`, printResult);
// TypeError: Cannot read property '1' of null
```
