### PR TITLE
Feature/scalar raw value

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "devInstall": "dev-env-installer install"
   },
   "dependencies": {
-    "underscore": "^1.8.3"
+
   },
   "typings":"dist/index.d.ts",
   "repository": {

--- a/src/yamlAST.ts
+++ b/src/yamlAST.ts
@@ -38,6 +38,7 @@ export interface YAMLScalar extends YAMLNode{
     value:string
     doubleQuoted?:boolean
     plainScalar?:boolean
+    rawValue:string
 }
 
 export interface YAMLMapping extends YAMLNode{
@@ -83,7 +84,8 @@ export function newScalar(v:string=""):YAMLScalar{
         value:v,
         kind:Kind.SCALAR,
         parent:null,
-        doubleQuoted:false
+        doubleQuoted:false,
+        rawValue:v
     }
 }
 export function newItems():YAMLSequence{


### PR DESCRIPTION
## Added `allowAnyEscape` option to parser.

``` YAML
name: "Agustin \{test}"
```

Is now parsed as `Scalar "Agustin \\{test}"`
## Added `rawValue` to Scalar, lets use this yaml fragment:

``` YAML
test: "hola\nmanola\{"
```

Before, and now without the new flag, we expect this result:

``` typescript
let yaml = `
test: "hola${'\\'}nmanola${'\\'}{"
`;

let result = yaml.load(yaml); 

result == { errors:
   [ YAMLException {
       name: 'YAMLException',
       reason: 'unknown escape sequence',
       mark:
        Mark {
          name: null,
          buffer: '\ntest: "hola\\nmanola\\{"\n\u0000',
          position: 21,
          line: 0,
          column: 20 },
       message: 'JS-YAML: unknown escape sequence at line 1, column 21' } ],
   ...
}
```

Now it works with the new `allowAnyEscape` flag

``` typescript

let options = { allowAnyEscape: true };
let yaml = `
test: "hola${'\\'}nmanola${'\\'}{"
`;

let result = yaml.load(yaml, options);

result == { errors: [],
  startPosition: 1,
  endPosition: 24,
  mappings:
   [ { key:
        { errors: [],
          startPosition: 1,
          endPosition: 5,
          value: 'test',
          kind: 0,
          parent: [Circular],
          doubleQuoted: false,
          rawValue: 'test',
          plainScalar: true },
       value:
        { errors: [],
          startPosition: 7,
          endPosition: 23,
          value: 'hola\nmanola\\{',
          kind: 0,
          parent: [Circular],
          doubleQuoted: true,
          rawValue: '"hola\\nmanola\\{"' }, // <-----
       startPosition: 1,
       endPosition: 23,
       kind: 1,
       parent: [Circular],
       errors: [] } ],
  kind: 2,
  parent: null }
```
