### PR TITLE
Fixed bug where mark.line wasn't correct when having duplicate key error

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -208,7 +208,7 @@ function throwErrorFromPosition(state, position: number, message) {
         return;
     }
     
-    var mark = new Mark(state.filename, state.input, position, line.line-1, (position - line.start));
+    var mark = new Mark(state.filename, state.input, position, line.line, (position - line.start));
     
     var error = new YAMLException(message, mark);
 


### PR DESCRIPTION
This PR fixes a bug where using mark.line would result in a negative value (-1) when ran on a yaml file such as:

apiVersion: v1
apiVersion: v2

mark.line was returning that there were duplicate key errors at line -1 and line 0 instead of line 0 and line 1.