### PR TITLE
Add functions to help determining the type of a scalar node

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,23 +9,27 @@ In additional to parsing YAML to AST, it has following features:
 * restoration after the errors and reporting errors as a part of AST nodes.
 * built-in support for `!include` tag used in RAML
 
+## Usage
+The type information below is relevant when using TypeScript, if using from JavaScript only the field/method information is relevant.
 
-`load` method can be used to load the tree and returns `YAMLNode` root.
+`load` method can be used to load the tree and returns a `YAMLNode`.
 
+### YAMLNode
 `YAMLNode` class is an ancestor for all node kinds.
-It's `kind` field determine node kind, one of `Kind` enum: `SCALAR`, `MAPPING`, `MAP`, `SEQ`, `ANCHOR_REF` or `INCLUDE_REF`. After node kind is determined, it can be casted to one of the `YAMLNode` descendants: `YAMLScalar`, `YAMLMapping`, `YamlMap`, `YAMLSequence` or `YAMLAnchorReference`.
+It's `kind` field determine node kind, one of `Kind` enum:
+  * `SCALAR`, `MAPPING`, `MAP`, `SEQ`, `ANCHOR_REF` or `INCLUDE_REF`.
+ 
+After node kind is determined, it can be cast to one of the `YAMLNode` descendants types:
+ * `YAMLScalar`, `YAMLMapping`, `YamlMap`, `YAMLSequence` or `YAMLAnchorReference`.
 
-`startPosition` and `endPosition` of `YAMLNode` class provide node range.
-
-`YAMLScalar` has string `value` field.
-
-`YAMLMapping` has `YAMLScalar` `key` and `YAMLNode` `value` fields.
-
-`YAMLSequence` has `YAMLNode[]` `items` field.
-
-`YamlMap` has `YAMLMapping[]` `mappings` field.
-
-`YAMLAnchorReference` has string `referencesAnchor` and `YAMLNode` `value`.
+| class | important members |
+|-------|-------------------|
+| `YAMLNode` | `startPosition` and `endPosition` provide node range.|
+| `YAMLScalar` | `string` `value` field |
+| `YAMLMapping` |`YAMLScalar` `key` and `YAMLNode` `value` fields | 
+| `YAMLSequence` | `YAMLNode[]` `items` field|
+| `YamlMap` | `YAMLMapping[]` `mappings` field|
+| `YAMLAnchorReference` | `string` `referencesAnchor` and `YAMLNode` `value`|
 
 
 

--- a/README.md
+++ b/README.md
@@ -31,5 +31,12 @@ After node kind is determined, it can be cast to one of the `YAMLNode` descendan
 | `YamlMap` | `YAMLMapping[]` `mappings` field|
 | `YAMLAnchorReference` | `string` `referencesAnchor` and `YAMLNode` `value`|
 
+### YAMLScalar
 
+Scalars are [one of the three main node types defined by YAML](http://www.yaml.org/spec/1.2/spec.html#scalar//) and are effectively leaf nodes.
 
+There are many factors that can influence the type of datum represent in scalar node (context, schema, tag, etc.).
+
+To help inspection of a `YAMLScalar` to determine its datatype when a document uses the [Core Schema](http://www.yaml.org/spec/1.2/spec.html#id2804923), you can pass the `YAMLScalar` to the `determineScalarType` function.  It will return an enum value indicating `null`, `bool`, `int`, `float`, or `string`.
+
+Once you know the type, there are also some helper functions to help read the value by passing them the string, `value`: `parseYamlBoolean`, `parseYamlFloat`, and `parseYamlInteger`.

--- a/package.json
+++ b/package.json
@@ -1,18 +1,17 @@
 {
   "name": "yaml-ast-parser",
   "version": "0.0.33",
-  "main": "dist/index.js",
+  "main": "dist/src/index.js",
   "scripts": {
     "build": "rimraf dist && tsc",
-    "pullall" : "dev-env-installer pullall",
-    "buildall" : "dev-env-installer buildall",
-    "testall" : "dev-env-installer testall",
-    "devInstall": "dev-env-installer install"
+    "pullall": "dev-env-installer pullall",
+    "buildall": "dev-env-installer buildall",
+    "testall": "dev-env-installer testall",
+    "devInstall": "dev-env-installer install",
+    "test": "npm run build && mocha dist/test"
   },
-  "dependencies": {
-
-  },
-  "typings":"dist/index.d.ts",
+  "dependencies": {},
+  "typings": "dist/src/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/mulesoft-labs/yaml-ast-parser.git"
@@ -28,9 +27,12 @@
     "url": "https://github.com/mulesoft-labs/yaml-ast-parser/issues"
   },
   "devDependencies": {
+    "@types/mocha": "^2.2.41",
+    "@types/node": "^8.0.0",
+    "dev-env-installer": "0.0.5",
+    "mocha": "^3.4.2",
+    "rimraf": "*",
     "typescript": "1.8.7",
-    "typings": "^0.5.1",
-    "dev-env-installer":"0.0.5",
-    "rimraf":"*"
+    "typings": "^0.5.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^2.2.41",
-    "@types/node": "^8.0.0",
+    "@types/node": "^0.12.0",
     "dev-env-installer": "0.0.5",
     "mocha": "^3.4.2",
     "rimraf": "*",

--- a/src/index.ts
+++ b/src/index.ts
@@ -173,3 +173,5 @@ export var loadAll             = loader.loadAll;
 export var safeLoad            = loader.safeLoad;
 export var dump                = dumper.dump;
 export var safeDump            = dumper.safeDump;
+
+export * from './scalarInference'

--- a/src/scalarInference.ts
+++ b/src/scalarInference.ts
@@ -1,0 +1,98 @@
+import { YAMLScalar } from './yamlAST'
+
+export function parseYamlBoolean(input: string): boolean {
+    if (["true", "True", "TRUE"].lastIndexOf(input) >= 0) {
+        return true;
+    }
+    else if (["false", "False", "FALSE"].lastIndexOf(input) >= 0) {
+        return false;
+    }
+    throw `Invalid boolean "${input}"`
+}
+
+function safeParseYamlInteger(input: string): number {
+    // Use startsWith when es6 methods becomes available
+    if (input.lastIndexOf('0o', 0) === 0) {
+        return parseInt(input.substring(2), 8)
+    }
+
+    return parseInt(input);
+}
+
+export function parseYamlInteger(input: string): number {
+    const result = safeParseYamlInteger(input)
+
+    if (isNaN(result)) {
+        throw `Invalid integer "${input}"`
+    }
+
+    return result;
+}
+
+export function parseYamlFloat(input: string): number {
+
+    if ([".nan", ".NaN", ".NAN"].lastIndexOf(input) >= 0) {
+        return NaN;
+    }
+
+    const infinity = /^([-+])?(?:\.inf|\.Inf|\.INF)$/
+    const match = infinity.exec(input)
+    if (match) {
+        return (match[1] === '-') ? -Infinity : Infinity;
+    }
+
+    const result = parseFloat(input)
+
+    if (!isNaN(result)) {
+        return result;
+    }
+
+    throw `Invalid float "${input}"`
+}
+
+export enum ScalarType {
+    null, bool, int, float, string
+}
+
+/** Determines the type of a scalar according to
+  * the YAML 1.2 Core Schema (http://www.yaml.org/spec/1.2/spec.html#id2804923)
+  */
+export function determineScalarType(node: YAMLScalar): ScalarType {
+    if (node === undefined) {
+        return ScalarType.null;
+    }
+
+    if (node.doubleQuoted || !node.plainScalar || node['singleQuoted']) {
+        return ScalarType.string
+    }
+
+    const value = node.value;
+
+    if (["null", "Null", "NULL", "~", ''].indexOf(value) >= 0) {
+        return ScalarType.null;
+    }
+
+    if (value === null || value === undefined) {
+        return ScalarType.null;
+    }
+
+    if (["true", "True", "TRUE", "false", "False", "FALSE"].indexOf(value) >= 0) {
+        return ScalarType.bool;
+    }
+
+    const base10 = /^[-+]?[0-9]+$/
+    const base8 = /^0o[0-7]+$/
+    const base16 = /^0x[0-9a-fA-F]+$/
+
+    if (base10.test(value) || base8.test(value) || base16.test(value)) {
+        return ScalarType.int;
+    }
+
+    const float = /^[-+]?(\.[0-9]+|[0-9]+(\.[0-9]*)?)([eE][-+]?[0-9]+)?$/
+    const infinity = /^[-+]?(\.inf|\.Inf|\.INF)$/
+    if (float.test(value) || infinity.test(value) || [".nan", ".NaN", ".NAN"].indexOf(value) >= 0) {
+        return ScalarType.float;
+    }
+
+    return ScalarType.string;
+}

--- a/test/scalarInference.test.ts
+++ b/test/scalarInference.test.ts
@@ -63,7 +63,14 @@ suite('determineScalarType', () => {
   .nan,
   "-123\n345"
 ]`)
-            assert.deepStrictEqual(node.items.map(n => determineScalarType(n)), [ScalarType.null, ScalarType.bool, ScalarType.int, ScalarType.float, ScalarType.float, ScalarType.float, ScalarType.string])
+
+            const expected = [ScalarType.null, ScalarType.bool, ScalarType.int, ScalarType.float, ScalarType.float, ScalarType.float, ScalarType.string]
+
+            for (var idx = 0; idx < node.items.length; idx++) {
+                var element = determineScalarType(node.items[idx]);
+                
+                assert.strictEqual(element, expected[idx]);
+            }
         })
     })
 

--- a/test/scalarInference.test.ts
+++ b/test/scalarInference.test.ts
@@ -1,0 +1,168 @@
+// Typings are available but need TypeScript 2
+declare var suite: any;
+declare var test: any;
+declare var require: any;
+
+var assert = require('assert');
+var {suite, test} = require('mocha');
+import { determineScalarType as sut, ScalarType, parseYamlBoolean, parseYamlInteger, parseYamlFloat } from '../src/scalarInference'
+
+import * as Yaml from '../src/yamlAST'
+import {safeLoad as loadYaml} from '../src/index'
+
+suite('determineScalarType', () => {
+
+    function determineScalarType(scalar: Yaml.YAMLDocument) {
+        return sut(<Yaml.YAMLScalar>scalar)
+    }
+
+    function safeLoad(input) {
+        return loadYaml(input, {})
+    }
+
+    let _test = test;
+
+    // http://www.yaml.org/spec/1.2/spec.html#id2805071
+    suite('Plain Tag Resolution', () => {
+
+        function test(name, type, acceptable) {
+            _test(name, function () {
+                for (const word of acceptable) {
+                    assert.strictEqual(determineScalarType(safeLoad(word)), type, word)
+                }
+            })
+        };
+
+        test('boolean', ScalarType.bool, ["true", "True", "TRUE", "false", "False", "FALSE"])
+
+        test("null", ScalarType.null, ["null", "Null", "NULL", "~", ""])
+        _test("null as from an array", function () {
+            const node = Yaml.newScalar('');
+            node.plainScalar = true;
+            assert.strictEqual(determineScalarType(node), ScalarType.null, "unquoted empty string")
+        })
+
+        test("integer", ScalarType.int, ["0", "0o7", "0x3A", "-19"])
+
+        test("float", ScalarType.float, ["0.", "-0.0", ".5", "+12e03", "-2E+05"])
+
+        test("float-infinity", ScalarType.float, [".inf", "-.Inf", "+.INF"])
+
+        test("float-NaN", ScalarType.float, [".nan", ".NaN", ".NAN"])
+
+        test("string", ScalarType.string, ["'true'", "TrUe", "nULl", "''", "'0'", '"1"', '" .5"', ".inF", ".nAn"])
+    })
+
+    suite('Flow style', () => {
+        test('still recognizes types', function () {
+            const node = <Yaml.YAMLSequence>safeLoad(`[ null,
+  true,
+  0,
+  0.,
+  .inf,
+  .nan,
+  "-123\n345"
+]`)
+            assert.deepStrictEqual(node.items.map(n => determineScalarType(n)), [ScalarType.null, ScalarType.bool, ScalarType.int, ScalarType.float, ScalarType.float, ScalarType.float, ScalarType.string])
+        })
+    })
+
+    suite('Block styles', () => {
+        var variations = ['>', '|', '>8', '|+1', '>-', '>+', '|-', '|+']
+
+        test('are always strings', function () {
+            for (const variant of variations) {
+                assert.deepEqual(determineScalarType(safeLoad(variant + "\n 123")), ScalarType.string);
+            }
+        })
+    })
+})
+
+suite('parseYamlInteger', () => {
+    test('decimal', function () {
+        assert.strictEqual(parseYamlInteger("0"), 0)
+        assert.strictEqual(parseYamlInteger("-19"), -19)
+        assert.strictEqual(parseYamlInteger("+1"), 1)
+    })
+
+    test('hexadecimal', function () {
+        assert.strictEqual(parseYamlInteger("0x3A"), 58)
+    })
+
+    test('octal', function () {
+        assert.strictEqual(parseYamlInteger("0o7"), 7)
+    })
+
+    test('otherwise', function () {
+        let error;
+        try {
+            parseYamlInteger("'1'")
+        }
+        catch (e) {
+            error = e;
+        }
+
+        assert(error, "should have thrown")
+    })
+})
+
+suite('parseYamlBoolean', () => {
+    test('true', function () {
+        for (const value of ["true", "True", "TRUE"]) {
+            assert.strictEqual(parseYamlBoolean(value), true, value);
+        }
+    })
+
+    test('false', function () {
+        for (const value of ["false", "False", "FALSE"]) {
+            assert.strictEqual(parseYamlBoolean(value), false, value);
+        }
+    })
+
+    test('otherwise', function () {
+        let error;
+        try {
+            parseYamlBoolean("tRUE")
+        }
+        catch (e) {
+            error = e;
+        }
+
+        assert(error, "should have thrown")
+    })
+})
+
+suite('parseYamlFloat', () => {
+    test('float', function () {
+        const values = ["0.", "-0.0", ".5", "+12e03", "-2E+05"]
+        const expected = [0, -0, 0.5, 12000, -200000]
+        for (var index = 0; index < values.length; index++) {
+            assert.strictEqual(parseYamlFloat(values[index]), expected[index])
+        }
+    })
+
+    test('NaN', function () {
+        for (const value of [".nan", ".NaN", ".NAN"]) {
+            assert(isNaN(parseYamlFloat(value)), `isNaN(${value})`)
+        }
+    })
+
+    test('infinity', function () {
+        assert.strictEqual(parseYamlFloat(".inf"),
+            Infinity)
+        assert.strictEqual(parseYamlFloat("-.Inf"), -Infinity)
+        assert.strictEqual(parseYamlFloat(".INF"), Infinity)
+    })
+
+    test('otherwise', function () {
+        let error;
+        try {
+            parseYamlFloat("text")
+        }
+        catch (e) {
+            error = e;
+        }
+
+        assert(error, "should have thrown")
+    })
+})

--- a/workspace.json
+++ b/workspace.json
@@ -23,6 +23,7 @@
   },
   "yaml-ast-parser" : {
     "build" : "npm run build",
+    "test": "npm run test",
     "gitUrl" : "https://github.com/mulesoft-labs/yaml-ast-parser.git",
     "gitBranch" : false
   },


### PR DESCRIPTION
I almost opened an issue because no type information is exposed on `YAMLScalar` nodes, but before I did realized that between the context that is available and the [YAML Spec](http://www.yaml.org/spec/1.2/spec.html) you generally can determine the type.

I spent a fair bit of time implementing and testing this checking, and would like to contribute it back so other users of the library can benefit if they need it too.  This updates the README with usage information for the added functions.