### PR TITLE
Export the contents of yamlAST instead of duplicating it

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,8 +3,8 @@
  * Created by kor on 06/05/15.
  */
 
-import loader = require('./loader');
-import dumper = require('./dumper');
+export {load, loadAll, safeLoad} from './loader';
+export {dump, safeDump} from './dumper';
 import Mark=require("./mark")
 export class YAMLException {
 
@@ -54,113 +54,9 @@ export class YAMLException {
     }
 }
 
-export enum Kind{
-    SCALAR,
-    MAPPING,
-    MAP,
-    SEQ,
-    ANCHOR_REF,
-    INCLUDE_REF
-}
+export * from './yamlAST'
+
 export type Error = YAMLException
-export interface YAMLDocument {
-    startPosition:number
-    endPosition:number
-    errors:YAMLException[]
-}
-export interface YAMLNode extends YAMLDocument{
-    startPosition:number
-    endPosition:number
-    kind:Kind
-    anchorId?:string
-    valueObject?:any
-    parent:YAMLNode
-    errors:YAMLException[]
-    value?:any
-    key?:any
-    mappings?:any
-}
-
-export interface YAMLAnchorReference extends YAMLNode{
-    referencesAnchor:string
-    value:YAMLNode
-}
-export interface YAMLScalar extends YAMLNode{
-    value:string
-    doubleQuoted?:boolean
-    plainScalar?:boolean
-}
-
-export interface YAMLMapping extends YAMLNode{
-    key:YAMLScalar
-    value:YAMLNode
-}
-export interface YAMLSequence extends YAMLNode{
-    items:YAMLNode[]
-}
-export interface YamlMap extends YAMLNode{
-    mappings:YAMLMapping[]
-}
-export function newMapping(key:YAMLScalar,value:YAMLNode):YAMLMapping{
-    var end = (value ? value.endPosition : key.endPosition + 1); //FIXME.workaround, end should be defied by position of ':'
-    //console.log('key: ' + key.value + ' ' + key.startPosition + '..' + key.endPosition + ' ' + value + ' end: ' + end);
-    var node = {
-        key: key,
-        value: value,
-        startPosition: key.startPosition,
-        endPosition: end,
-        kind: Kind.MAPPING,
-        parent: null,
-        errors: []
-    };
-    return node
-}
-export function newAnchorRef(key:string,start:number,end:number,value:YAMLNode):YAMLAnchorReference{
-    return {
-        errors:[],
-        referencesAnchor:key,
-        value:value,
-        startPosition:start,
-        endPosition:end,
-        kind:Kind.ANCHOR_REF,
-        parent:null
-    }
-}
-export function newScalar(v:string=""):YAMLScalar{
-    return {
-        errors:[],
-        startPosition:-1,
-        endPosition:-1,
-        value:v,
-        kind:Kind.SCALAR,
-        parent:null,
-        doubleQuoted:false
-    }
-}
-export function newItems():YAMLSequence{
-    return {
-        errors:[],
-        startPosition:-1,
-        endPosition:-1,
-        items:[],
-        kind:Kind.SEQ,
-        parent:null
-    }
-}
-export function newSeq():YAMLSequence{
-    return newItems();
-}
-export function newMap(mappings?: YAMLMapping[]):YamlMap{
-    return {
-        errors:[],
-        startPosition:-1,
-        endPosition:-1,
-        mappings: mappings ? mappings : [],
-        kind:Kind.MAP,
-        parent:null
-    }
-}
-
 
 function deprecated(name) {
     return function () {
@@ -168,8 +64,3 @@ function deprecated(name) {
     };
 }
 
-export var load= loader.load;
-export var loadAll             = loader.loadAll;
-export var safeLoad            = loader.safeLoad;
-export var dump                = dumper.dump;
-export var safeDump            = dumper.safeDump;


### PR DESCRIPTION
Export the contents of yamlAST instead of duplicating them.  This should fix #11 and help reduce recurrence of such issues.