### PR TITLE
Return YAMLNode

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -150,7 +150,7 @@ class State{
     line:number
     lineStart:number
     lineIndent:number
-    documents:ast.YAMLDocument[];
+    documents:ast.YAMLNode[];
     kind:string
     result:ast.YAMLNode
     tag:string

--- a/src/yamlAST.ts
+++ b/src/yamlAST.ts
@@ -25,8 +25,19 @@ export interface YAMLNode extends YAMLDocument{
     valueObject?:any
     parent:YAMLNode
     errors:YAMLException[]
+    /**
+     * @deprecated Inspect kind and cast to the appropriate subtype instead.
+     */
     value?:any
+
+    /**
+     * @deprecated Inspect kind and cast to the appropriate subtype instead.
+     */
     key?:any
+
+    /**
+     * @deprecated Inspect kind and cast to the appropriate subtype instead.
+     */
     mappings?:any
 }
 


### PR DESCRIPTION
Changes load commands to return YAMLNode rather than YAMLDocument

The README documents YAMLNode as the return type, but prior to this change the document needed to be explicitly cast to YAMLNode to do much of interest with it.

Also uses JSDoc to marks some members on the base-type YAMLNode that are only applicable to specific node kinds as deprecated.