### PR TITLE
Support astral characters

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -347,7 +347,10 @@ function captureSegment(state:State, start:number, end:number, checkJson:boolean
           throwError(state, 'expected valid JSON character');
         }
       }
+    } else if (PATTERN_NON_PRINTABLE.test(_result)) {
+      throwError(state, 'the stream contains non-printable characters');
     }
+
     scalar.value+=_result;
     scalar.endPosition=end;
   }
@@ -1741,8 +1744,8 @@ function loadDocuments(input:string, options) {
   input = String(input);
   options = options || {};
 
-    let inputLength = input.length;
-    if (inputLength !== 0) {
+  let inputLength = input.length;
+  if (inputLength !== 0) {
 
     // Add tailing `\n` if not exists
     if (0x0A/* LF */ !== input.charCodeAt(inputLength - 1) &&
@@ -1757,10 +1760,6 @@ function loadDocuments(input:string, options) {
   }
 
   var state = new State(input, options);
-
-  if (PATTERN_NON_PRINTABLE.test(state.input)) {
-    throwError(state, 'the stream contains non-printable characters');
-  }
 
   // Use 0 as string terminator. That significantly simplifies bounds check.
   state.input += '\0';

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -25,7 +25,7 @@ var CHOMPING_STRIP = 2;
 var CHOMPING_KEEP  = 3;
 
 
-var PATTERN_NON_PRINTABLE         = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x84\x86-\x9F\uD800-\uDFFF\uFFFE\uFFFF]/;
+var PATTERN_NON_PRINTABLE         = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x84\x86-\x9F\uFFFE\uFFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF]/;
 var PATTERN_NON_ASCII_LINE_BREAKS = /[\x85\u2028\u2029]/;
 var PATTERN_FLOW_INDICATORS       = /[,\[\]\{\}]/;
 var PATTERN_TAG_HANDLE            = /^(?:!|!!|![a-z\-]+!)$/i;

--- a/test/characterSet.test.ts
+++ b/test/characterSet.test.ts
@@ -3,6 +3,15 @@ import * as YAML from '../src/';
 import * as util from './testUtil';
 
 suite('YAML Syntax', () => {
+	test('Allow astral characters', function () {
+		const key = '𝑘𝑒𝑦';
+		const value = '𝑣𝑎𝑙𝑢𝑒';
+		const document = YAML.safeLoad(`${key}: ${value}`);
+	
+		assert.deepEqual(document.mappings[0].key.value, key);
+		assert.deepEqual(document.mappings[0].value.value, value);
+	});
+
 	test('Forbid non-printable characters', function () {
 		testErrors('\x01', [{
 			line: 1,

--- a/test/characterSet.test.ts
+++ b/test/characterSet.test.ts
@@ -1,0 +1,58 @@
+import { assert } from "chai";
+import * as YAML from '../src/';
+import * as util from './testUtil';
+
+suite('YAML Syntax', () => {
+	test('Forbid non-printable characters', function () {
+		testErrors('\x01', [{
+			line: 1,
+			column: 0,
+			message:'the stream contains non-printable characters',
+			isWarning: false
+		}]);
+
+		testErrors('\x7f', [{
+			line: 1,
+			column: 0,
+			message:'the stream contains non-printable characters',
+			isWarning: false
+		}]);
+
+		testErrors('\x9f', [{
+			line: 1,
+			column: 0,
+			message:'the stream contains non-printable characters',
+			isWarning: false
+		}]);
+	});
+
+	test('Forbid lone surrogates', function () {
+		testErrors('\udc00\ud800', [{
+			line: 1,
+			column: 0,
+			message:'the stream contains non-printable characters',
+			isWarning: false
+		}]);
+	});
+
+	test('Allow non-printable characters inside quoted scalars', function () {
+		const key = '"\x7f\x9f\udc00\ud800"';
+		const document = YAML.safeLoad(key);
+
+		assert.deepEqual(document.value, '\x7f\x9f\udc00\ud800');
+	});
+
+	test('Forbid control sequences inside quoted scalars', function () {
+		testErrors('"\x03"', [{
+			line: 0,
+			column: 2,
+			message:'expected valid JSON character',
+			isWarning: false
+		}]);
+	});
+
+});
+
+function testErrors(input: string, expectedErrors: util.TestError[]) {
+	util.testErrors(input, expectedErrors);
+}

--- a/workspace.json
+++ b/workspace.json
@@ -2,24 +2,20 @@
   "raml-1-parser" : {
     "build" : "npm run build",
     "test" : "gulp test",
-    "gitUrl" : "https://github.com/raml-org/raml-js-parser-2.git",
-    "gitBranch": "develop"
+    "gitUrl" : "https://github.com/raml-org/raml-js-parser-2.git"
   },
   "raml-definition-system" : {
     "build" : "npm run build",
-    "gitUrl" : "https://github.com/raml-org/raml-definition-system.git",
-    "gitBranch": "develop"
+    "gitUrl" : "https://github.com/raml-org/raml-definition-system.git"
   },
   "raml-typesystem" : {
     "build" : "npm run build",
     "test" : "npm run test-cov",
-    "gitUrl" : "https://github.com/raml-org/raml-typesystem.git",
-    "gitBranch": "develop"
+    "gitUrl" : "https://github.com/raml-org/raml-typesystem.git"
   },
   "ts-structure-parser" : {
     "build" : "npm run build",
-    "gitUrl" : "https://github.com/mulesoft-labs/ts-structure-parser.git",
-    "gitBranch": "develop"
+    "gitUrl" : "https://github.com/mulesoft-labs/ts-structure-parser.git"
   },
   "yaml-ast-parser" : {
     "build" : "npm run build",
@@ -29,8 +25,7 @@
   },
   "ts-model" : {
     "build" : "npm run build",
-    "gitUrl" : "https://github.com/mulesoft-labs/ts-model.git",
-    "gitBranch": "develop"
+    "gitUrl" : "https://github.com/mulesoft-labs/ts-model.git"
   }
 }
 


### PR DESCRIPTION
Fixes #31 

This is basically a port of 2 commits from the original repo `js-yaml`:

* https://github.com/nodeca/js-yaml/commit/a14d85c58eeb820c48e66e1a185e88ada22c9000 to get errors in case of one-line documents (any call to `safeLoad` or `load` functions returned `undefined` otherwise).
* https://github.com/nodeca/js-yaml/commit/e26fe9078e8879006fdc4be1f34983d084ccf114 to allow astral characters such as "🚣" or "𝑣𝑎𝑙𝑢𝑒", which are in the authorized range #x10000-#x10FFFF